### PR TITLE
add tuple field-index form

### DIFF
--- a/doc/erlang.tex
+++ b/doc/erlang.tex
@@ -176,6 +176,15 @@ is an instance of tuple type \var{name}
 
 The \code{(\var{name} is?)} form expands to \code{(lambda (x) (\var{name} is? x))}.
 
+\index{tuple!field-index@\code{field-index}}
+\begin{syntax}
+  \code{(\var{name} field-index \var{field})}
+\end{syntax}
+\expandsto{} an integer \var{n}, such that \code{(vector-ref \var{instance} \var{n})}
+returns \var{instance}.\var{field}
+
+Avoid using this form when possible, as it leaks implementation details.
+
 % ----------------------------------------------------------------------------
 \subsection {Pattern Matching}
 

--- a/src/swish/erlang.ms
+++ b/src/swish/erlang.ms
@@ -227,6 +227,11 @@
      (<point> open p [51 mustang])
      p)
    "invalid field")
+  (assert-syntax-error
+   (let ()
+     (define-tuple <point> x y)
+     (<point> field-index z))
+   "unknown field")
   )
 
 (mat t9 ()
@@ -509,6 +514,15 @@
          (let ([x 'bound-x] [y 'bound-y])
            (<point> open p p. (x y))
            (list x y p.x p.y)))))))
+  (assert
+   (equal?
+    '(5 4)
+    (let ()
+      (define-tuple <point> x y)
+      (let ([p (<point> make [x 5] [y 4])])
+        (list
+         (vector-ref p (<point> field-index x))
+         (vector-ref p (<point> field-index y)))))))
   (assert-error bad-tuple
     (let ()
       (define-tuple <box> content)

--- a/src/swish/erlang.ss
+++ b/src/swish/erlang.ss
@@ -648,6 +648,14 @@
                     [() is?]
                     [(e) #`(#,is? e)]
                     [else (syntax-case x ())]))]
+               [(name field-index fn)
+                (and (eq? (datum field-index) 'field-index)
+                     (syntax-datum-eq? #'fn #'field))
+                (datum->syntax #'* (find-index #'fn #'(field ...) 1))]
+               ...
+               [(name field-index fn)
+                (eq? (datum field-index) 'field-index)
+                (syntax-violation #f "unknown field" x #'fn)]
                [(name fn e)
                 (syntax-datum-eq? #'fn #'field)
                 (with-syntax ([getter (replace-source x #'(name fn))])


### PR DESCRIPTION
As we briefly discussed last week, this lets referee `vector-set!` `reported_values_hash` fields without copying the entire response.