### PR TITLE
JSON: support special floating-point values

### DIFF
--- a/.github/workflows/run-mats.yml
+++ b/.github/workflows/run-mats.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-11, ubuntu-20.04, windows-2022]
+        os: [macos-12, ubuntu-20.04, ubuntu-22.04, windows-2022]
         chez: [v9.5.8]
     runs-on: ${{ matrix.os }}
     steps:

--- a/doc/json.tex
+++ b/doc/json.tex
@@ -35,8 +35,9 @@
 
 \section {Introduction}
 
-The programming interface includes procedures for JavaScript Object
-Notation (JSON)~\cite{RFC7159}.
+The programming interface includes procedures for JavaScript Object Notation
+(JSON)~\cite{RFC7159}. In order to support all floating-point values, it extends the
+specification with Infinity, -Infinity, and NaN.
 
 This implementation translates JavaScript types into the following
 Scheme types:
@@ -46,7 +47,10 @@ Scheme types:
 
   \code{true} & \code{\#t} \\
   \code{false} & \code{\#f} \\
-  \code{null} & \code{\#\textbackslash nul} \\
+  \code{null} & symbol \code{null} \\
+  \code{Infinity} & \code{+inf.0} \\
+  \code{-Infinity} & \code{-inf.0} \\
+  \code{NaN} & \code{+nan.0} \\
   \var{string} & \var{string} \\
   \var{number} & \var{number} \\
   \var{array} & \var{list} \\

--- a/src/swish/json.ms
+++ b/src/swish/json.ms
@@ -73,9 +73,12 @@
     'ok]))
 
 (define test-objs
-  `(#(#\nul "null")
-    #(#t "true")
+  `(#(#t "true")
     #(#f "false")
+    #(null "null")
+    #(+inf.0 "Infinity")
+    #(-inf.0 "-Infinity")
+    #(+nan.0 "NaN")
     #(1 "1")
     #(3.1415 "3.1415")
     #(-1 "-1")
@@ -116,8 +119,8 @@
     #(,(json:make-object [,'foo (json:make-object [bar #t])])
       "{\"foo\":{\"bar\":true}}")
 
-    #((-123 "foo" ,(json:make-object [bar '()]) #\nul)
-      "[-123,\"foo\",{\"bar\":[]},null]")
+    #((-123 "foo" ,(json:make-object [bar '()]) #t #f null +inf.0 -inf.0 +nan.0)
+      "[-123,\"foo\",{\"bar\":[]},true,false,null,Infinity,-Infinity,NaN]")
     #(,(json:make-object [,(gensym "bar" "unique-name") 456] [#{foo lish} 789])
       "{\"#{foo lish}\":789,\"#{bar unique-name}\":456}")
     #(,(json:make-object [,(string->symbol "#{foo not-gensym") 123])
@@ -383,12 +386,12 @@
    ([#(EXIT #(bad-arg json:write -1))
      (catch (json:write (open-output-string) 12 -1))]
     [#(EXIT #(invalid-datum 1/2)) (catch (json:object->string 1/2))]
-    [#(EXIT #(invalid-datum +inf.0)) (catch (json:object->string +inf.0))]
-    [#(EXIT #(invalid-datum -inf.0)) (catch (json:object->string -inf.0))]
-    [#(EXIT #(invalid-datum +nan.0)) (catch (json:object->string +nan.0))]
     [#(EXIT unexpected-eof) (catch (json:string->object "t"))]
     [#(EXIT unexpected-eof) (catch (json:string->object "f"))]
     [#(EXIT unexpected-eof) (catch (json:string->object "n"))]
+    [#(EXIT unexpected-eof) (catch (json:string->object "Infinit"))]
+    [#(EXIT unexpected-eof) (catch (json:string->object "-I"))]
+    [#(EXIT unexpected-eof) (catch (json:string->object "Na"))]
     [#(EXIT #(unexpected-input #\, 6))
      (catch (json:string->object "{\"foo\",12}"))]
     [#(EXIT unexpected-eof) (catch (json:string->object "\""))]


### PR DESCRIPTION
- Extend the JSON specification with Infinity, -Infinity, and NaN.
- Map null to the symbol null instead of the character nul.
- Run the automated tests on macos-12 instead of macos-11, and run them on ubuntu-22.04.