### PR TITLE
fix define-tuple is? predicate to handle alias or library rename

### DIFF
--- a/.github/workflows/run-mats.yml
+++ b/.github/workflows/run-mats.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-13, macos-14, ubuntu-24.04, windows-2022]
+        os: [macos-15, ubuntu-24.04, windows-2025]
         chez: [v10.2.0]
     runs-on: ${{ matrix.os }}
     steps:

--- a/src/swish/dsm.ms
+++ b/src/swish/dsm.ms
@@ -263,3 +263,47 @@
     "|(F 0 2 (3) 9)"
     "|(F 0 3 () 11)"
     "|14"))
+
+(mat dsm-alias ()
+  (define-syntactic-monad M a b)
+  ;; alias should work
+  (alias P M)
+  #; ;; The following macro may work, but stock identifier-syntax will not work.
+  (define-syntax (P x)
+    (syntax-case x ()
+      [(k x ...) (with-implicit (k M) #'(M x ...))]))
+  (define-tuple <testf> f0 f1 call)
+  (define-syntax (build x)
+    (syntax-case x ()
+      [(_ A)
+       ;; resort to with-implicit for DRY test-helper macro
+       (with-implicit (A a b)
+         #'(let ()
+             (A define (f0 y) (list 'f0 a b y))
+             (<testf> make
+               [f0 f0]
+               [f1 (A lambda (z) `#(f1 ,a ,b ,z))]
+               [call (lambda (f a b d) (A f () d))]
+               )))]))
+  (match-let*
+   ([`(<testf> [f0 ,Mf0] [f1 ,Mf1] [call ,Mcall]) (build M)]
+    [`(<testf> [f0 ,Pf0] [f1 ,Pf1] [call ,Pcall]) (build P)]
+    [(f0 1 2 3) (Mcall Mf0 1 2 3)]
+    [(f0 2 3 4) (Mcall Pf0 2 3 4)]
+    [(f0 3 4 5) (Pcall Mf0 3 4 5)]
+    [(f0 4 5 6) (Pcall Pf0 4 5 6)]
+    [#(f1 1 2 3) (Mcall Mf1 1 2 3)]
+    [#(f1 2 3 4) (Mcall Pf1 2 3 4)]
+    [#(f1 3 4 5) (Pcall Mf1 3 4 5)]
+    [#(f1 4 5 6) (Pcall Pf1 4 5 6)]
+    [(a: (5 3 1) b: (6 4 2))
+     (let ([a '()] [b '()])
+       (M let lp1 () ([ls '(1 2 3 4 5 6)])
+         (match ls
+           [() `(a: ,a b: ,b)]
+           [(,h . ,t)
+            (guard (odd? h))
+            (P lp1 ([a (cons h a)]) t)]
+           [(,h . ,t)
+            (let ([b (cons h b)]) (M lp1 () t))])))])
+   'ok))

--- a/src/swish/erlang.ms
+++ b/src/swish/erlang.ms
@@ -287,14 +287,78 @@
      (equal? x (match x [,(exp <= (5 #f foo . ,_)) exp])))))
 
 (mat t14 ()
-  ;; Using identifier-syntax or a library rename, the tuple
-  ;; constructor should always create the original type.
+  ;; Tuple constructors, accessors, predicates, and copy operations
+  ;; should expect the symbolic type named in the original define-tuple
+  ;; form regardless of alias, identifier-syntax, or library renames.
+  #0=
+  (define-syntax exercise-variants
+    (syntax-rules ()
+      [(_ <t0> [<t1> robust?] ...)
+       (match-let*
+        ([,p0 (<t0> make [x 1] [y 2])]
+         [,x0 (<t0> x p0)]
+         [,y0 (<t0> y p0)]
+         [,getx0 (<t0> x)]
+         [,gety0 (<t0> y)]
+         [,is0? (<t0> is?)]
+         [#f (is0? '#(<t0>))]
+         [,swap0 (lambda (p) (<t0> copy* p [x y] [y x]))]
+         [,swapped (swap0 p0)]
+         [,zap0 (lambda (p) (<t0> copy p [x 0]))]
+         [,zapped (zap0 p0)])
+        (match-let*
+         ([,p1 (<t1> make [x 1] [y 2])]
+          [,@p0 p1]
+          [,@x0 (<t1> x p1)]
+          [,@y0 (<t1> y p1)]
+          [,@x0 (getx0 p1)]
+          [,@y0 (gety0 p1)]
+          [,getx1 (<t1> x)]
+          [,gety1 (<t1> y)]
+          [,@x0 (getx1 p0)]
+          [,@y0 (gety1 p0)]
+          [,is1? (<t1> is?)]
+          [#t (is0? p1)]
+          [#t (is1? p0)]
+          [#f (is1? '#(<t0>))]
+          [#f (is1? '#(<t1> x y))]
+          [,swap1 (lambda (p) (<t1> copy* p [x y] [y x]))]
+          [,@swapped (swap0 p1)]
+          [,@swapped (swap1 p0)]
+          [,zap1 (lambda (p) (<t1> copy p [x 0]))]
+          [,@zapped (zap0 p1)]
+          [,@zapped (zap1 p0)]
+          [`(<t0> [x ,@x0] [y ,@y0]) p1])
+         (meta-cond
+          [robust?
+           ;; At present, match cannot resolve the fields if <t1> expands to
+           ;; <t0>. That might change if we moved some match code into the <t0>
+           ;; macro transformer, but it could be difficult to generate good
+           ;; error messages.
+           (match-let* ([`(<t1> [x ,@x0] [y ,@y0]) p0])
+             'ok)]))
+        ...)]))
   (let ()
     (define-tuple <point> x y)
     (define-syntax <should-be-a-point> (identifier-syntax <point>))
-    (assert
-     (equal? (<point> make [x 1] [y 2])
-       (<should-be-a-point> make [x 1] [y 2])))))
+    (alias <also-a-point> <point>)
+    (exercise-variants <point> [<should-be-a-point> #f] [<also-a-point> #t]))
+  (eval
+   (let ([A (gensym "A")] [B (gensym "B")])
+     `(begin
+        (library (,A)
+          (export <point>)
+          (import (scheme) (swish erlang))
+          (define-tuple <point> x y))
+
+        (library (,B)
+          (export <should-be-a-point>)
+          (import (rename (,A) (<point> <should-be-a-point>))))
+
+        (let ()
+          (import (scheme) (swish erlang) (,A) (,B))
+          ,'#0#
+          (exercise-variants <point> [<should-be-a-point> #t]))))))
 
 ;; single-clause match -> match-let*
 (mat t15 ()
@@ -1615,6 +1679,20 @@
                             (match-let* ([x x] [y not] [snoo z] [now now])
                               'ok)])))])
        inject))
+   ;; alias works, since we can resolve the property, but identifier-syntax wouldn't work
+   (let ()
+     (define-match-extension P0
+       (lambda (v pattern)
+         (syntax-case pattern ()
+           [(_quasi (p var . rest))
+            #`((bind var `(,#,v P0 p . rest)))])))
+     (alias P1 P0)
+     (match-let*
+      ([`(P0 z 1 4) 'one]
+       [(one P0 P0 1 4) z]
+       [`(P1 g 7 11) 'two]
+       [(two P0 P1 7 11) g])
+      'ok))
    ))
 
 ;; generate predictable source annotations for stack dump tests

--- a/src/swish/erlang.ss
+++ b/src/swish/erlang.ss
@@ -621,21 +621,21 @@
                 (and (eq? (datum make) 'make)
                      (valid-bindings? #'bindings))
                 #`(vector 'name #,@(make-tuple #'(field ...) #'bindings))]
-               [(name copy e . bindings)
+               [(_name copy e . bindings)
                 (and (eq? (datum copy) 'copy)
                      (valid-bindings? #'bindings))
                 (handle-copy x #'e #'bindings 'copy)]
-               [(name copy* e . bindings)
+               [(_name copy* e . bindings)
                 (and (eq? (datum copy*) 'copy*)
                      (valid-bindings? #'bindings))
                 (handle-copy x #'e #'bindings 'copy*)]
-               [(name open expr prefix field-names)
+               [(_name open expr prefix field-names)
                 (and (eq? (datum open) 'open) (identifier? #'prefix))
                 (handle-open x #'expr #'prefix #'field-names)]
-               [(name open expr field-names)
+               [(_name open expr field-names)
                 (eq? (datum open) 'open)
                 (handle-open x #'expr #f #'field-names)]
-               [(name is? . args)
+               [(_name is? . args)
                 (eq? (datum is?) 'is?)
                 (let ([is?
                        #'(lambda (x)
@@ -646,35 +646,35 @@
                     [() is?]
                     [(e) #`(#,is? e)]
                     [else (syntax-case x ())]))]
-               [(name field-index fn)
+               [(_name field-index fn)
                 (and (eq? (datum field-index) 'field-index)
                      (syntax-datum-eq? #'fn #'field))
                 (datum->syntax #'* (find-index #'fn #'(field ...) 1))]
                ...
-               [(name field-index fn)
+               [(_name field-index fn)
                 (eq? (datum field-index) 'field-index)
                 (syntax-violation #f "unknown field" x #'fn)]
-               [(name fn e)
+               [(_name fn e)
                 (syntax-datum-eq? #'fn #'field)
                 (with-syntax ([getter (replace-source x #'(name fn))])
                   #`(getter e))]
                ...
-               [(name fn)
+               [(_name fn)
                 (syntax-datum-eq? #'fn #'field)
                 #`(lambda (x)
                     (unless (name is? x)
                       (throw `#(bad-tuple name ,x ,#,(find-source x))))
                     (#3%vector-ref x #,(find-index #'fn #'(field ...) 1)))]
                ...
-               [(name no-check fn e)
+               [(_name no-check fn e)
                 (and (eq? (datum no-check) 'no-check)
                      (syntax-datum-eq? #'fn #'field))
                 #`(#3%vector-ref e #,(find-index #'fn #'(field ...) 1))]
                ...
-               [(name fn)
+               [(_name fn)
                 (identifier? #'fn)
                 (syntax-violation #f "unknown field" x #'fn)]
-               [(name fn expr)
+               [(_name fn expr)
                 (identifier? #'fn)
                 (syntax-violation #f "unknown field" x #'fn)]
                ))

--- a/src/swish/options.ms
+++ b/src/swish/options.ms
@@ -384,6 +384,19 @@
       [11 (foo y b)]
       )
      'ok))
+  ;; alias works
+  (let ()
+    (define-options foo
+      (required [x])
+      (optional [y (default 0)]))
+    (alias bar foo)
+    (alias <zap> <foo>)
+    (match-let*
+     ([,a (foo [x 11])]
+      [11 (bar x a)]
+      [0 (bar y a)]
+      [`(<zap> [x 11] [y 0]) a])
+     'ok))
   )
 
 (mat procedure/arity ()


### PR DESCRIPTION
Fix the macro generated by `define-tuple` so that the `is?` predicate expects the original name despite the use of alias and library renaming, which is consistent with `make`. Add regression tests for other exported macros that generate macros that could be susceptible to a similar bug.

Update the Github test runners.