### PR TITLE
json: check ,key in json:extend-object

### DIFF
--- a/src/swish/errors.ss
+++ b/src/swish/errors.ss
@@ -46,6 +46,7 @@
       [#(bad-match ,v ,src) (format "Pattern match failed~a: ~s." (src->english src) v)]
       [#(bad-tuple ,name ,x ,src) (format "Invalid type for tuple ~a~a: ~s." name (src->english src) x)]
       [#(json:invalid-datum ,what) (format "Invalid datum while writing JSON: ~s." what)]
+      [#(json:invalid-key ,what ,src) (format "Invalid key~a: ~s" (src->english src) what)]
       [#(json:unexpected ,context ,what ,position ,name)
        (let ([eof? (eof-object? what)])
          (format "Unexpected ~:[input~;end-of-file~]~a~@[ while parsing a JSON ~a~]~@[: ~s~]."

--- a/src/swish/json.ms
+++ b/src/swish/json.ms
@@ -1057,7 +1057,13 @@
   (assert-syntax-error (json:make-object ["str" 123]) "invalid key \"str\" in" match-form)
   (assert-syntax-error (json:extend-object x ["str" 123]) "invalid key \"str\" in" match-form)
   (match-let*
-   ([#(EXIT #(bad-arg json:write -1))
+   ([#(EXIT #(json:invalid-key "x" ,_))
+     (catch (json:make-object [,"x" 123]))]
+    [#(EXIT #(json:invalid-key "y" ,_))
+     (catch (json:extend-object (json:make-object) [,"y" 123]))]
+    ["Invalid key at offset 123 of bug.ss: \"B-flat\""
+     (exit-reason->english `#(json:invalid-key "B-flat" #(at 123 "bug.ss")))]
+    [#(EXIT #(bad-arg json:write -1))
      (catch (json:write (open-output-string) 12 -1))]
     [,ip (open-input-string "wrong")]
     [#(EXIT #(bad-arg json:write ,@ip))

--- a/src/swish/json.ss
+++ b/src/swish/json.ss
@@ -95,10 +95,15 @@
          ...
          ht)]))
 
+  (define (ensure-key x src)
+    (unless (symbol? x)
+      (throw `#(json:invalid-key ,x ,src)))
+    x)
+
   (define-syntax (parse-key x)
     (syntax-case x (unquote)
       [(_ id form) (identifier? #'id) #'(quote id)]
-      [(_ (unquote e) form) #'e]
+      [(_ (unquote e) form) #`(ensure-key e #,(find-source #'form))]
       [(_ key form) (syntax-error #'form (format "invalid key ~s in" (datum key)))]))
 
   (define (verify-json-object who x)


### PR DESCRIPTION
Add missing check to ensure ,key evaluates to a symbol in json:extend-object and json:make-object so our use of optimize-level 3 symbol-hashtable-set! is safe.